### PR TITLE
Higher Order Components (HOC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,37 +92,96 @@ public function middleware(store:StoreMethods<ApplicationState>, action:TodoActi
 
 ## React Connect
 
-### High Order Component (HOC) approach (TODO)
-
-**Note: externs for this approach are NOT included.**
+### High Order Component (HOC) approach
 
 Normally for React, you're expected to use react-redux's `connect` function:
 http://redux.js.org/docs/basics/UsageWithReact.html
 
-HOC will create a wrapped component that maps the redux state into component **props**.
+HOC will create a component wrapper that maps the redux state into the wrapped component's **props**.
 
-Using HOCs is a bit awkward in Haxe's class-oriented approach, one way to do it is to store
-the connected class reference in a static field:
+A partial implementation of the above link's example would be:
 
 ```haxe
-class MyComponent extends ReactComponent 
+// A ReactConnector providing `TodoListProps`
+class VisibleTodoList extends ReactConnector<TodoListProps>
 {
-	static public var Connected = ReactRedux.connect(mapStateToProps)(MyComponent);
-	
-	static function mapStateToProps(state:State)
+	// Default component to wrap
+	// If not set, children props will be updated
+	// If not set & no children, will render a React empty node
+	// If set but children available, children props will be updated instead of using this component
+	static var wrappedComponent:TodoList;
+
+	static function mapStateToProps(state:ApplicationState, ownProps:Dynamic):Partial<TodoListProps>
 	{
-		...
-	} 
-	...
+		return {
+			todos: getVisibleTodos(state.todoList.todos, state.todoList.visibilityFilter)
+		}
+	}
+
+	static function getVisibleTodos(todos:Array<TodoData>, filter:TodoFilter)
+	{
+		return switch (filter) {
+			case SHOW_ALL: todos;
+			case SHOW_COMPLETED: todos.filter(function(t) return t.completed);
+			case SHOW_ACTIVE: todos.filter(function(t) return !t.completed);
+		}
+	}
+
+	@:connect
+	static function onTodoClick(dispatch:Dispatch, id:Int):Void
+	{
+		dispatch(TodoAction.Toggle(id));
+	}
+
+	/*
+	Alternative to `@:connect`:
+	```
+	static function mapDispatchToProps(dispatch:Dispatch, ownProps:Dynamic):Partial<TodoListProps>
+	{
+		return {
+			onTodoClick: function(id) {
+				return dispatch(TodoAction.Toggle(id));
+			}
+		};
+	}
+	```
+	*/
 }
 ```
 
 ```haxe
+@:jsxStatic('render')
+class TodoList
+{
+	static public function render(props:TodoListProps)
+	{
+		var todos = props.todos.map(function(todo) return jsx('
+			<$Todo
+				key=${todo.id}
+				{...todo}
+				onClick=${props.onTodoClick.bind(todo.id)}
+			/>
+		'));
+
+		return jsx('
+			<ul>
+				$todos
+			</ul>
+		');
+	}
+}
+```
+
+You can then call the HOC like this:
+
+```haxe
 	override function render() 
 	{
-		return jsx('<MyComponent.Connected />');
+		return jsx('<$VisibleTodoList />');
 	}
 ```
+
+A complete implementation is available in an [example app](https://github.com/kLabz/haxe-redux-todo).
 
 
 ### Macro approach

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ public function middleware(store:StoreMethods<ApplicationState>, action:TodoActi
 
 ## React Connect
 
-### High Order Component (HOC) approach
+### Higher Order Component (HOC) approach
 
 Normally for React, you're expected to use react-redux's `connect` function:
 http://redux.js.org/docs/basics/UsageWithReact.html
@@ -102,15 +102,9 @@ HOC will create a component wrapper that maps the redux state into the wrapped c
 A partial implementation of the above link's example would be:
 
 ```haxe
-// A ReactConnector providing `TodoListProps`
-class VisibleTodoList extends ReactConnector<TodoListProps>
+// A ReactConnector providing `TodoListProps`, with `TodoList` as default wrapped component
+class VisibleTodoList extends ReactConnector<TodoList, TodoListProps>
 {
-	// Default component to wrap
-	// If not set, children props will be updated
-	// If not set & no children, will render a React empty node
-	// If set but children available, children props will be updated instead of using this component
-	static var wrappedComponent:TodoList;
-
 	static function mapStateToProps(state:ApplicationState, ownProps:Dynamic):Partial<TodoListProps>
 	{
 		return {
@@ -127,15 +121,6 @@ class VisibleTodoList extends ReactConnector<TodoListProps>
 		}
 	}
 
-	@:connect
-	static function onTodoClick(dispatch:Dispatch, id:Int):Void
-	{
-		dispatch(TodoAction.Toggle(id));
-	}
-
-	/*
-	Alternative to `@:connect`:
-	```
 	static function mapDispatchToProps(dispatch:Dispatch, ownProps:Dynamic):Partial<TodoListProps>
 	{
 		return {
@@ -144,8 +129,6 @@ class VisibleTodoList extends ReactConnector<TodoListProps>
 			}
 		};
 	}
-	```
-	*/
 }
 ```
 

--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,0 +1,2 @@
+# Add support for @:connect on react components
+--macro redux.react.ReactConnectorMacro.addBuilder()

--- a/redux/macro/MacroUtil.hx
+++ b/redux/macro/MacroUtil.hx
@@ -1,0 +1,78 @@
+package redux.macro;
+
+import haxe.macro.ComplexTypeTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+
+@:publicFields
+class MacroUtil {
+	static function unifyComplexTypes(type1:ComplexType, type2:ComplexType):Bool
+	{
+		if (type1 == null && type2 == null) return true;
+		if (type1 == null || type2 == null) return false;
+
+		return TypeTools.unify(
+			ComplexTypeTools.toType(type1),
+			ComplexTypeTools.toType(type2)
+		);
+	}
+
+	static function getAnonymousFields(complexType:ComplexType):Array<ClassField>
+	{
+		var type = ComplexTypeTools.toType(complexType);
+
+		return switch (type) {
+			case TType(_.get().type => t, _):
+				switch (t)
+				{
+					case TAnonymous(_.get() => {fields: fields, status: _}): fields;
+					default: null;
+				}
+
+			case TAnonymous(_.get() => {fields: fields, status: _}): fields;
+			default: null;
+		}
+	}
+
+	static function printFunctionSignature(
+		args:Array<Type>,
+		ret:Type
+	) {
+		return args
+			.concat([ret])
+			.map(TypeTools.toString)
+			.map(function(arg) return arg.indexOf('->') > 0 ? '($arg)' : arg)
+			.join(' -> ');
+	}
+
+	static function getPartialType(type:ComplexType):ComplexType
+	{
+		return TPath({
+			name: 'Partial',
+			pack: ['react'],
+			params: [TPType(type)]
+		});
+	}
+
+	static function isDispatch(complexType:ComplexType):Bool
+	{
+		var type = ComplexTypeTools.toType(complexType);
+		return TypeTools.toString(type) == 'redux.Dispatch';
+	}
+
+	static function extractMetaString(metadata:MetaAccess, name:String):String
+	{
+		if (!metadata.has(name)) return null;
+
+		var metas = metadata.extract(name);
+		if (metas.length == 0) return null;
+
+		var params = metas[0].params;
+		if (params.length == 0) return null;
+		
+		return ExprTools.getValue(params[0]);
+	}
+}

--- a/redux/macro/MacroUtil.hx
+++ b/redux/macro/MacroUtil.hx
@@ -37,6 +37,14 @@ class MacroUtil {
 		}
 	}
 
+	static function hasField(fields:Array<Field>, fieldName:String):Bool
+	{
+		for (f in fields)
+			if (f.name == fieldName) return true;
+
+		return false;
+	}
+
 	static function printFunctionSignature(
 		args:Array<Type>,
 		ret:Type
@@ -72,7 +80,7 @@ class MacroUtil {
 
 		var params = metas[0].params;
 		if (params.length == 0) return null;
-		
+
 		return ExprTools.getValue(params[0]);
 	}
 }

--- a/redux/react/ReactConnect.hx
+++ b/redux/react/ReactConnect.hx
@@ -1,7 +1,0 @@
-package redux.react;
-
-typedef ReactConnector<TComponentProps> = ReactConnect<TComponentProps, Dynamic>;
-typedef ReactConnectorOfProps<TComponentProps, OwnProps> = ReactConnect<TComponentProps, OwnProps>;
-
-@:autoBuild(redux.react.ReactConnectorMacro.buildContainer())
-class ReactConnect<TComponentProps, OwnProps> {}

--- a/redux/react/ReactConnect.hx
+++ b/redux/react/ReactConnect.hx
@@ -1,0 +1,7 @@
+package redux.react;
+
+typedef ReactConnector<TComponentProps> = ReactConnect<TComponentProps, Dynamic>;
+typedef ReactConnectorOfProps<TComponentProps, OwnProps> = ReactConnect<TComponentProps, OwnProps>;
+
+@:autoBuild(redux.react.ReactConnectorMacro.buildContainer())
+class ReactConnect<TComponentProps, OwnProps> {}

--- a/redux/react/ReactConnector.hx
+++ b/redux/react/ReactConnector.hx
@@ -1,0 +1,33 @@
+package redux.react;
+
+typedef TVoid = {};
+
+/**
+  A react-redux connector designed for a component TComponent, providing TProps
+  from redux store.
+*/
+typedef ReactConnector<TComponent, TProps> = ReactConnect<TComponent, TProps, TVoid>;
+
+/**
+  A react-redux connector designed for a component TComponent, providing TProps
+  from redux store and the connector's props (TOwnProps)
+*/
+typedef ReactConnectorOfProps<TComponent, TComponentProps, TOwnProps> = ReactConnect<TComponent, TComponentProps, TOwnProps>;
+
+/**
+  A react-redux connector for use with any component compatible with TProps.
+  Will return an empty react node at runtime if used without children, with an
+  error message if compiled with -debug.
+*/
+typedef ReactGenericConnector<TProps> = ReactConnect<TVoid, TProps, TVoid>;
+
+/**
+  A react-redux connector for use with any component compatible with TProps.
+  This connector also accepts props of type TOwnProps.
+  Will return an empty react node at runtime if used without children, with an
+  error message if compiled with -debug.
+*/
+typedef ReactGenericConnectorOfProps<TProps, TOwnProps> = ReactConnect<TVoid, TProps, TOwnProps>;
+
+@:autoBuild(redux.react.ReactConnectorMacro.buildContainer())
+class ReactConnect<TComponent, TComponentProps, TOwnProps> {}

--- a/redux/react/ReactConnectorMacro.hx
+++ b/redux/react/ReactConnectorMacro.hx
@@ -16,7 +16,42 @@ enum ConnectedFunction {
 }
 
 class ReactConnectorMacro {
-	static inline var DEFAULT_JSX_STATIC:String = 'Connected';
+	static inline var CONNECT_META = ':connect';
+	static inline var DEFAULT_CONNECTED_FIELD_NAME = '_connected';
+	static inline var DEFAULT_JSX_STATIC = 'Connected';
+
+	static function addBuilder() react.ReactComponentMacro.appendBuilder(buildComponent);
+
+	static function buildComponent(inClass:ClassType, fields:Array<Field>):Array<Field>
+	{
+		if (inClass.meta.has(CONNECT_META))
+		{
+			if (inClass.meta.has(JsxStaticMacro.META_NAME))
+				Context.fatalError(
+					'Cannot use @${CONNECT_META} and @${JsxStaticMacro.META_NAME} on the same component',
+					inClass.pos
+				);
+
+			var fieldName = DEFAULT_CONNECTED_FIELD_NAME;
+			while (hasField(fields, fieldName)) fieldName = '_$fieldName';
+
+			var connectMeta = inClass.meta.extract(CONNECT_META).shift();
+			var connectParams = getConnectParams(connectMeta.params, fields);
+
+			fields.push({
+				access: [APublic, AStatic],
+				name: fieldName,
+				kind: FVar(null, macro redux.react.ReactRedux.connect($a{connectParams})($i{inClass.name})),
+				doc: null,
+				meta: null,
+				pos: connectMeta.pos
+			});
+
+			inClass.meta.add(JsxStaticMacro.META_NAME, [macro $v{fieldName}], connectMeta.pos);
+		}
+
+		return fields;
+	}
 
 	static function buildContainer():Array<Field>
 	{
@@ -91,6 +126,44 @@ class ReactConnectorMacro {
 
 				default:
 			}
+	}
+
+	static function getConnectParams(params:Array<Expr>, fields:Array<Field>):Array<Expr>
+	{
+		if (params.length > 0) return params;
+
+		var mapStateToProps:Null<Expr> = null;
+		var mapDispatchToProps:Null<Expr> = null;
+		var mergeProps:Null<Expr> = null;
+		var options:Null<Expr> = null;
+
+		for (f in fields)
+		{
+			if (Lambda.has(f.access, AStatic))
+			{
+				switch (f.name)
+				{
+					case 'mapStateToProps': mapStateToProps = macro mapStateToProps;
+					case 'mapDispatchToProps': mapDispatchToProps = macro mapDispatchToProps;
+					case 'mergeProps': mergeProps = macro mergeProps;
+					case 'options': options = macro options;
+					default:
+				}
+			}
+		}
+
+		if (mapStateToProps == null && mapDispatchToProps == null && mergeProps == null && options == null)
+			return [];
+
+		if (mapStateToProps == null) mapStateToProps = macro null;
+		if (mapDispatchToProps == null && (mergeProps != null || options != null)) mapDispatchToProps = macro null;
+		if (mergeProps == null && options != null) mergeProps = macro null;
+
+		var ret = [mapStateToProps];
+		if (mapDispatchToProps != null) ret.push(mapDispatchToProps);
+		if (mergeProps != null) ret.push(mergeProps);
+		if (options != null) ret.push(options);
+		return ret;
 	}
 
 	static function getJsxStaticName(inClass:ClassType):String

--- a/redux/react/ReactConnectorMacro.hx
+++ b/redux/react/ReactConnectorMacro.hx
@@ -1,0 +1,640 @@
+package redux.react;
+
+import haxe.macro.ComplexTypeTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+import react.ReactMacro;
+import redux.macro.MacroUtil.*;
+
+enum ConnectedFunction {
+	WithDispatch(field:Field);
+	WithDispatchAndOwnProps(field:Field);
+}
+
+@:access(react.ReactMacro)
+class ReactConnectorMacro {
+	static inline var DEFAULT_JSX_STATIC:String = 'Connected';
+
+	static function buildContainer():Array<Field>
+	{
+		var inClass = Context.getLocalClass().get();
+		var fields = Context.getBuildFields();
+
+		var componentPropsType = macro :Dynamic;
+		var ownPropsType = macro :Dynamic;
+		var jsxStatic = getJsxStaticName(inClass);
+
+		switch (inClass.superClass)
+		{
+			case {params: params, t: _.toString() => 'redux.react.ReactConnect'}:
+				componentPropsType = TypeTools.toComplexType(params[0]);
+				ownPropsType = TypeTools.toComplexType(params[1]);
+
+			default:
+				Context.fatalError('You cannot inherit from a react connector', inClass.pos);
+		}
+
+		checkNonStaticFields(fields);
+		checkReservedFields(fields, jsxStatic);
+
+		var wrappedComponent = getWrappedComponent(fields, componentPropsType);
+		var connectedFunctions = getConnectedFunctions(fields, ownPropsType, componentPropsType, inClass);
+
+		var mapStateToProps = getMapStateToProps(fields, ownPropsType, componentPropsType);
+		var mapDispatchToProps = getMapDispatchToProps(fields, ownPropsType, componentPropsType);
+		var mergeProps = getMergeProps(fields, ownPropsType, componentPropsType);
+		var options = getOptions(fields);
+
+		if (mapDispatchToProps == null)
+			addMapDispatchToProps(
+				fields,
+				connectedFunctions,
+				ownPropsType,
+				componentPropsType
+			);
+		else if (connectedFunctions.length > 0)
+			addMapDispatchToPropsWarnings(connectedFunctions);
+
+		if (mapStateToProps == null) addMapStateToProps(fields);
+		if (mergeProps == null) addMergeProps(fields);
+		if (options == null) addOptions(fields);
+
+		addConnected(jsxStatic, fields);
+		addRender(fields, componentPropsType, wrappedComponent, inClass);
+
+		return fields;
+	}
+
+	static function checkNonStaticFields(fields:Array<Field>):Void
+	{
+		for (field in fields)
+			if (!Lambda.has(field.access, AStatic))
+				Context.fatalError('React connectors cannot have non-static fields', field.pos);
+	}
+
+	static function checkReservedFields(fields:Array<Field>, jsxStatic:String):Void
+	{
+		for (field in fields)
+			switch (field.name) {
+				case '$jsxStatic', 'get_$jsxStatic', 'render':
+					Context.fatalError('Field ${field.name} is reserved', field.pos);
+
+				default:
+			}
+	}
+
+	static function getJsxStaticName(inClass:ClassType):String
+	{
+		if (inClass.meta.has(':jsxStatic')) 
+			return extractMetaString(inClass.meta, ':jsxStatic');
+
+		inClass.meta.add(':jsxStatic', [macro $v{DEFAULT_JSX_STATIC}], inClass.pos);
+		return DEFAULT_JSX_STATIC;
+	}
+
+	static function getWrappedComponent(fields:Array<Field>, componentPropsType:ComplexType):ComplexType
+	{
+		var wrappedComponent = Lambda.find(fields, function(field) {
+			return field.name == 'wrappedComponent';
+		});
+		
+		if (wrappedComponent == null) return null;
+
+		return switch (wrappedComponent.kind) {
+			case FVar(t, _): t;
+			default: null;
+		};
+	}
+
+	static function getConnectedFunctions(
+		fields:Array<Field>,
+		propsType:ComplexType,
+		componentPropsType:ComplexType,
+		inClass:ClassType
+	):Array<ConnectedFunction> {
+		return fields
+			.filter(function(field) {
+				return Lambda.find(field.meta, function(meta) {
+					return meta.name == ':connect';
+				}) != null;
+			})
+			.map(function(field) {
+				switch (field.kind)
+				{
+					case FFun({args: args, expr: _, params: _, ret: ret}):
+						if (args.length == 0)
+							Context.fatalError(
+								'Connected functions must accept a Dispatch argument',
+								field.pos
+							);
+
+						if (!isDispatch(args[0].type))
+							Context.fatalError(
+								'First argument of connected functions must be Dispatch',
+								field.pos
+							);
+
+						var fields = getAnonymousFields(componentPropsType);
+						if (fields == null)
+							Context.fatalError(
+								'Wrapped components props must be anonymous objects', 
+								inClass.pos
+							);
+
+						for (ref in fields)
+							if (ref.name == field.name)
+								return validateConnectedFunction(
+									ref, 
+									field, 
+									propsType, 
+									args.slice(1), 
+									ret
+								);
+
+					default:
+						Context.fatalError('Only functions can be connected with @:connect', field.pos);
+				}
+
+				return null;
+			});
+	}
+
+	static function validateConnectedFunction(
+		ref:ClassField,
+		field:Field,
+		propsType:ComplexType,
+		fieldArgs:Array<FunctionArg>,
+		fieldRet:ComplexType
+	):ConnectedFunction {
+		var refType = TypeTools.follow(ref.type);
+		var needsOwnProps = false;
+
+		switch (refType)
+		{
+			case TFun(args, ret):
+				if (fieldRet == null)
+					Context.warning(
+						'You should specify the return type to allow type checking against props\n' +
+						'(should be ${TypeTools.toString(ret)} to match props)',
+						field.pos
+					);
+				else if (!TypeTools.unify(ret, ComplexTypeTools.toType(fieldRet)))
+				{
+					Context.fatalError('Return type does not match props', field.pos);
+				}
+
+				// trace(printFunctionSignature(
+				// 	fieldArgs.map(function(arg) return arg.type == null ? null : ComplexTypeTools.toType(arg.type)), 
+				// 	ComplexTypeTools.toType(fieldRet)
+				// ));
+
+				if (args.length < fieldArgs.length)
+				{
+					if (unifyComplexTypes(fieldArgs[0].type, propsType))
+					{
+						fieldArgs = fieldArgs.slice(1);
+						needsOwnProps = true;
+					}
+				}
+
+				if (args.length != fieldArgs.length)
+				{
+					var functionSign = printFunctionSignature(args.map(function(arg) return arg.t), ret);
+					var wantedSign = 
+						'dispatch: Dispatch -> ' + functionSign
+						+ '\nor\n dispatch: Dispatch -> ownProps: ' 
+						+ ComplexTypeTools.toString(propsType)
+						+ ' -> ' + functionSign;
+
+					Context.fatalError(
+						'Field `${ref.name}` does not match props type. Wanted:\n $wantedSign',
+						field.pos
+					);
+				}
+
+				for (i in 0...args.length)
+				{
+					var wantedType = args[i].t;
+					var wantedTypeStr = TypeTools.toString(wantedType);
+
+					var fieldArg = fieldArgs[i];
+					var fieldName = fieldArg.name;
+					var fieldType = fieldArg.type;
+
+					if (fieldArg.type == null)
+					{
+						Context.warning(
+							'You should specify the type for argument `$fieldName`\n'
+							+ '(should be $wantedTypeStr to match props)',
+							field.pos
+						);
+					}
+					else if (!TypeTools.unify(wantedType, ComplexTypeTools.toType(fieldType)))
+					{
+						var fieldTypeStr = ComplexTypeTools.toString(fieldType);
+
+						Context.fatalError(
+							'Argument `$fieldName` does not match props:\n'
+							+ '$fieldTypeStr should be $wantedTypeStr',
+							field.pos
+						);
+					}
+				}
+
+			default:
+				Context.fatalError(
+					'Only functions can be connected with @:connect',
+					field.pos
+				);
+		}
+
+		return needsOwnProps ? WithDispatchAndOwnProps(field) : WithDispatch(field);
+	}
+
+	static function getMapStateToProps(
+		fields:Array<Field>,
+		propsType:ComplexType,
+		componentPropsType:ComplexType
+	):Field {
+		for (field in fields)
+		{
+			if (field.name == 'mapStateToProps')
+			{
+				switch (field.kind)
+				{
+					case FFun({args: args, ret: ret}):
+						if (args.length == 0 || args.length > 2)
+							Context.fatalError(
+								'mapStateToProps must accept one or two arguments',
+								field.pos
+							);
+
+						if (args.length == 2 && !unifyComplexTypes(args[1].type, propsType))
+							Context.fatalError(
+								'mapStateToProps: second argument must match '
+								+ 'the container\'s props type.',
+								field.pos
+							);
+
+						if (!unifyComplexTypes(ret, componentPropsType))
+							if (!unifyComplexTypes(ret, getPartialType(componentPropsType)))
+								Context.fatalError(
+									'mapStateToProps must return the wrapped component\'s '
+									+ 'props type (or a Partial<> of it)',
+									field.pos
+								);
+
+					default:
+						Context.fatalError('mapStateToProps must be a function', field.pos);
+				}
+
+				return field;
+			}
+		}
+
+		return null;
+	}
+
+	static function getMapDispatchToProps(
+		fields:Array<Field>,
+		propsType:ComplexType,
+		componentPropsType:ComplexType
+	):Field {
+		for (field in fields)
+		{
+			if (field.name == 'mapDispatchToProps')
+			{
+				switch (field.kind)
+				{
+					case FFun({args: args, ret: ret}):
+						if (args.length == 0 || args.length > 2)
+							Context.fatalError(
+								'mapDispatchToProps must accept one or two arguments',
+								field.pos
+							);
+
+						if (!isDispatch(args[0].type))
+							Context.fatalError(
+								'mapDispatchToProps: first argument must of type Dispatch',
+								field.pos
+							);
+
+						if (args.length == 2 && !unifyComplexTypes(args[1].type, propsType))
+							Context.fatalError(
+								'mapDispatchToProps: second argument must match '
+								+ 'the container\'s props type.',
+								field.pos
+							);
+
+						if (!unifyComplexTypes(ret, componentPropsType))
+							if (!unifyComplexTypes(ret, getPartialType(componentPropsType)))
+								Context.fatalError(
+									'mapDispatchToProps must return the wrapped component\'s '
+									+ 'props type (or a Partial<> of it)',
+									field.pos
+								);
+
+					default:
+						Context.fatalError(
+							'Current implementation only handles mapDispatchToProps as a function',
+							field.pos
+						);
+				}
+
+				return field;
+			}
+		}
+
+		return null;
+	}
+
+	static function getMergeProps(
+		fields:Array<Field>,
+		propsType:ComplexType,
+		componentPropsType:ComplexType
+	):Field {
+		for (field in fields)
+		{
+			if (field.name == 'mergeProps')
+			{
+				switch (field.kind)
+				{
+					case FFun({args: args, ret: ret}):
+						if (args.length != 3)
+							Context.fatalError(
+								'mergeProps must accept three arguments',
+								field.pos
+							);
+
+						if (!unifyComplexTypes(args[0].type, componentPropsType))
+							if (!unifyComplexTypes(args[0].type, getPartialType(componentPropsType)))
+								Context.fatalError(
+									'mergeProps: first argument must match the wrapped '
+									+ 'component\'s props type (or a Partial<> of it)',
+									field.pos
+								);
+
+						if (!unifyComplexTypes(args[1].type, componentPropsType))
+							if (!unifyComplexTypes(args[1].type, getPartialType(componentPropsType)))
+								Context.fatalError(
+									'mergeProps: second argument must match the wrapped '
+									+ 'component\'s props type (or a Partial<> of it)',
+									field.pos
+								);
+
+						if (!unifyComplexTypes(args[2].type, propsType))
+							Context.fatalError(
+								'mergeProps: third argument must match the container\'s props type.',
+								field.pos
+							);
+
+						if (!unifyComplexTypes(ret, componentPropsType))
+							Context.fatalError(
+								'mergeProps must return the wrapped component\'s props type',
+								field.pos
+							);
+
+					default:
+						Context.fatalError('mergeProps must be a function', field.pos);
+				}
+
+				return field;
+			}
+		}
+
+		return null;
+	}
+
+	static function getOptions(fields:Array<Field>):Field
+	{
+		for (field in fields)
+		{
+			if (field.name == 'options')
+			{
+				var connectOptionsType:ComplexType = macro :redux.react.ReactRedux.ConnectOptions;
+
+				switch (field.kind)
+				{
+					case FVar(type), FProp(_, _, type, _):
+						if (!unifyComplexTypes(type, connectOptionsType))
+							if (!unifyComplexTypes(type, getPartialType(connectOptionsType)))
+								Context.fatalError(
+									'Connect options must be a ConnectOptions '
+									+ ' or a Partial<ConnectOptions>',
+									field.pos
+								);
+
+
+					default:
+						Context.fatalError('Invalid connect options', field.pos);
+				}
+
+				return field;
+			}
+		}
+
+		return null;
+	}
+
+	static function addMapDispatchToPropsWarnings(connectedFunctions:Array<ConnectedFunction>)
+	{
+		for (field in connectedFunctions)
+			switch (field) {
+				case WithDispatch(f), WithDispatchAndOwnProps(f):
+					Context.warning(
+						'@:connect functions will not be connected by the macro '
+						+ 'when you define mapDispatchToProps',
+						f.pos
+					);
+			}
+	}
+
+	static function addMapDispatchToProps(
+		fields:Array<Field>,
+		connectedFunctions:Array<ConnectedFunction>,
+		propsType:ComplexType,
+		componentPropsType:ComplexType
+	) {
+		fields.push({
+			name: 'mapDispatchToProps',
+			doc: null,
+			meta: [],
+			access: [AStatic],
+			kind: FFun({
+				args: [
+					{type: macro :redux.Redux.Dispatch, name: 'dispatch'},
+					{type: propsType, name: 'ownProps', opt: true}
+				],
+				params: [],
+				ret: getPartialType(componentPropsType),
+				expr: mapDispatchToPropsExpr(connectedFunctions)
+			}),
+			pos: Context.currentPos()
+		});
+	}
+
+	static function mapDispatchToPropsExpr(connectedFunctions:Array<ConnectedFunction>)
+	{
+		var propsFields = [
+			for (connectedFunction in connectedFunctions)
+				switch (connectedFunction) {
+					case WithDispatch(field):
+						{
+							field: field.name,
+							expr: macro $i{field.name}.bind(dispatch)
+						};
+
+					case WithDispatchAndOwnProps(field):
+						{
+							field: field.name,
+							expr: macro $i{field.name}.bind(dispatch, ownProps)
+						};
+				}
+		];
+
+		return {
+			expr: EBlock([{
+				expr: EReturn({
+					expr: EObjectDecl(propsFields),
+					pos: Context.currentPos()
+				}),
+				pos: Context.currentPos()
+			}]),
+			pos: Context.currentPos()
+		};
+	}
+
+	static function addConnected(jsxStatic:String, fields:Array<Field>)
+	{
+		fields.push({
+			name: jsxStatic,
+			access: [AStatic, APublic],
+			kind: FProp('get', 'null', macro :react.React.CreateElementType),
+			pos: Context.currentPos()
+		});
+
+		fields.push({
+			name: 'get_$jsxStatic',
+			doc: null,
+			meta: [],
+			access: [AStatic],
+			kind: FFun({
+				args: [],
+				params: [],
+				ret: macro :react.React.CreateElementType,
+				expr: getConnectedExpr(jsxStatic)
+			}),
+			pos: Context.currentPos()
+		});
+	}
+
+	static function getConnectedExpr(jsxStatic:String)
+	{
+		return macro {
+			if ($i{jsxStatic} == null)
+				$i{jsxStatic} = redux.react.ReactRedux.connect(
+					mapStateToProps,
+					mapDispatchToProps,
+					mergeProps,
+					options
+				)(render);
+
+			return $i{jsxStatic};
+		};
+	}
+
+	static function addRender(
+		fields:Array<Field>,
+		componentPropsType:ComplexType,
+		wrappedComponent:ComplexType,
+		inClass:ClassType
+	) {
+		var componentName = switch (ComplexTypeTools.toType(wrappedComponent)) {
+			case TInst(compClass, _):
+				compClass.get().name;
+			
+			case null: 
+				null;
+
+			default:
+				Context.fatalError(
+					'Invalid wrapped component for React Container',
+					inClass.pos
+				);
+		};
+
+		fields.push({
+			name: 'render',
+			doc: null,
+			meta: [],
+			access: [AStatic],
+			kind: FFun({
+				args: [{
+					type: componentPropsType,
+					name: 'props'
+				}],
+				params: [],
+				ret: null,
+				expr: renderExpr(componentName, inClass.pos)
+			}),
+			pos: Context.currentPos()
+		});
+	}
+
+	static function renderExpr(componentName:String, pos:Position)
+	{
+		var jsx = macro null;
+
+		if (componentName != null) {
+			var jsxStr = '<' + componentName + ' {...props} />';
+			jsx = ReactMacro.parseJsx(jsxStr, pos);
+		}
+
+		return macro {
+			var children = untyped props.children;
+
+			if (children != null && react.React.isValidElement(children))
+			{
+				return react.React.Children.map(
+					children, 
+					function(child) return react.React.cloneElement(child, props)
+				);
+			} else {
+				return ${jsx};
+			}
+		};
+	}
+
+	static function addMapStateToProps(fields:Array<Field>)
+	{
+		fields.push({
+			name: 'mapStateToProps',
+			access: [AStatic],
+			kind: FProp('default', 'null', macro :Dynamic, macro null),
+			pos: Context.currentPos()
+		});
+	}
+
+	static function addMergeProps(fields:Array<Field>)
+	{
+		fields.push({
+			name: 'mergeProps',
+			access: [AStatic],
+			kind: FProp('default', 'null', macro :Dynamic, macro null),
+			pos: Context.currentPos()
+		});
+	}
+
+	static function addOptions(fields:Array<Field>)
+	{
+		fields.push({
+			name: 'options',
+			access: [AStatic],
+			kind: FProp('default', 'null', macro :Dynamic, macro null),
+			pos: Context.currentPos()
+		});
+	}
+}

--- a/redux/react/ReactRedux.hx
+++ b/redux/react/ReactRedux.hx
@@ -1,5 +1,6 @@
 package redux.react;
 
+import haxe.Constraints.Function;
 import haxe.extern.EitherType;
 import redux.Redux;
 import react.Partial;
@@ -12,19 +13,19 @@ import react.React.CreateElementType;
 #end
 extern class ReactRedux
 {
-
-	public static function connect(
-		?mapStateToProps: EitherType<Dynamic -> Dynamic -> Dynamic, Dynamic -> ?Dynamic -> Dynamic>,
-		?mapDispatchToProps: EitherType<Dynamic -> Dynamic -> Dynamic, Dynamic -> ?Dynamic -> Dynamic>,
-		?mergeProps: Dispatch -> Dynamic -> Dynamic -> Dynamic,
+	// https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options
+	public static function connect<TStateProps, TDispatchProps, TOwnProps, TProps>(
+		?mapStateToProps: Function,
+		?mapDispatchToProps: Dynamic,
+		?mergeProps: TStateProps -> TDispatchProps -> TOwnProps -> TProps,
 		?options: Partial<ConnectOptions>
 	): CreateElementType -> CreateElementType;
-
 }
 
 typedef ConnectAdvancedOptions = {
 	/**
-		Computes the connector component's displayName property relative to that of the wrapped component. Usually overridden by wrapper functions.
+		Computes the connector component's displayName property relative to
+		that of the wrapped component. Usually overridden by wrapper functions.
 		Default value: name => 'ConnectAdvanced(' + name + ')'
 	*/
 	var getDisplayName: String -> String;
@@ -36,25 +37,32 @@ typedef ConnectAdvancedOptions = {
 	var methodName: String;
 
 	/**
-		If defined, a property named this value will be added to the props passed to the wrapped component. Its value will be the number of times the component has been rendered, which can be useful for tracking down unnecessary re-renders.
+		If defined, a property named this value will be added to the props
+		passed to the wrapped component. Its value will be the number of times
+		the component has been rendered, which can be useful for tracking down
+		unnecessary re-renders.
 		Default value: undefined
 	*/
 	var renderCountProp: String;
 
 	/**
-		Controls whether the connector component subscribes to redux store state changes. If set to false, it will only re-render on componentWillReceiveProps.
+		Controls whether the connector component subscribes to redux store
+		state changes. If set to false, it will only re-render on
+		componentWillReceiveProps.
 		Default value: true
 	*/
 	var shouldHandleStateChanges: Bool;
 
 	/**
-		The key of props/context to get the store. You probably only need this if you are in the inadvisable position of having multiple stores.
+		The key of props/context to get the store. You probably only need this
+		if you are in the inadvisable position of having multiple stores.
 		Default value: 'store'
 	*/
 	var storeKey: String;
 
 	/**
-		If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
+		If true, stores a ref to the wrapped component instance and makes it
+		available via getWrappedInstance() method.
 		Default value: false
 	*/
 	var withRef: Bool;
@@ -64,7 +72,12 @@ typedef ConnectOptions = {
 	> ConnectAdvancedOptions,
 
 	/**
-		If true, connect() will avoid re-renders and calls to mapStateToProps, mapDispatchToProps, and mergeProps if the relevant state/props objects remain equal based on their respective equality checks. Assumes that the wrapped component is a “pure” component and does not rely on any input or state other than its props and the selected Redux store’s state.
+		If true, connect() will avoid re-renders and calls to mapStateToProps,
+		mapDispatchToProps, and mergeProps if the relevant state/props objects
+		remain equal based on their respective equality checks. Assumes that
+		the wrapped component is a “pure” component and does not rely on any
+		input or state other than its props and the selected Redux store’s
+		state.
 		Default value: true
 	**/
 	var pure: Bool;

--- a/redux/react/ReactRedux.hx
+++ b/redux/react/ReactRedux.hx
@@ -1,0 +1,95 @@
+package redux.react;
+
+import haxe.extern.EitherType;
+import redux.Redux;
+import react.Partial;
+import react.React.CreateElementType;
+
+#if reactredux_global
+@:native('ReactRedux')
+#else
+@:jsRequire('react-redux')
+#end
+extern class ReactRedux
+{
+
+	public static function connect(
+		?mapStateToProps: EitherType<Dynamic -> Dynamic -> Dynamic, Dynamic -> ?Dynamic -> Dynamic>,
+		?mapDispatchToProps: EitherType<Dynamic -> Dynamic -> Dynamic, Dynamic -> ?Dynamic -> Dynamic>,
+		?mergeProps: Dispatch -> Dynamic -> Dynamic -> Dynamic,
+		?options: Partial<ConnectOptions>
+	): CreateElementType -> CreateElementType;
+
+}
+
+typedef ConnectAdvancedOptions = {
+	/**
+		Computes the connector component's displayName property relative to that of the wrapped component. Usually overridden by wrapper functions.
+		Default value: name => 'ConnectAdvanced(' + name + ')'
+	*/
+	var getDisplayName: String -> String;
+
+	/**
+		Shown in error messages. Usually overridden by wrapper functions.
+		Default value: 'connectAdvanced'
+	*/
+	var methodName: String;
+
+	/**
+		If defined, a property named this value will be added to the props passed to the wrapped component. Its value will be the number of times the component has been rendered, which can be useful for tracking down unnecessary re-renders.
+		Default value: undefined
+	*/
+	var renderCountProp: String;
+
+	/**
+		Controls whether the connector component subscribes to redux store state changes. If set to false, it will only re-render on componentWillReceiveProps.
+		Default value: true
+	*/
+	var shouldHandleStateChanges: Bool;
+
+	/**
+		The key of props/context to get the store. You probably only need this if you are in the inadvisable position of having multiple stores.
+		Default value: 'store'
+	*/
+	var storeKey: String;
+
+	/**
+		If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
+		Default value: false
+	*/
+	var withRef: Bool;
+}
+
+typedef ConnectOptions = {
+	> ConnectAdvancedOptions,
+
+	/**
+		If true, connect() will avoid re-renders and calls to mapStateToProps, mapDispatchToProps, and mergeProps if the relevant state/props objects remain equal based on their respective equality checks. Assumes that the wrapped component is a “pure” component and does not rely on any input or state other than its props and the selected Redux store’s state.
+		Default value: true
+	**/
+	var pure: Bool;
+
+	/**
+		When pure, compares incoming store state to its previous value.
+		Default value: strictEqual (===)
+	**/
+	var areStatesEqual: Dynamic -> Dynamic -> Bool;
+
+	/**
+		When pure, compares incoming props to its previous value.
+		Default value: shallowEqual
+	**/
+	var areOwnPropsEqual: Dynamic -> Dynamic -> Bool;
+
+	/**
+		When pure, compares the result of mapStateToProps to its previous value.
+		Default value: shallowEqual
+	**/
+	var areStatePropsEqual: Dynamic -> Dynamic -> Bool;
+
+	/**
+		When pure, compares the result of mergeProps to its previous value.
+		Default value: shallowEqual
+	**/
+	var areMergedPropsEqual: Dynamic -> Dynamic -> Bool;
+}


### PR DESCRIPTION
## Higher Order Components (HOC)

This approach aims to allow the creation of container components as described on [ReactRedux documentation](http://redux.js.org/docs/basics/UsageWithReact.html#implementing-container-components), as an alternative to the `IConnectedComponent` approach.

The HOC approach (already mentioned as a TODO in the current readme) seem closer to the usual React approach, and may make transitioning from React/Redux to haxe-react/haxe-redux easier.

The separation between the HOC and its wrapped component is made clear here, since the HOC can only do its container role, and nothing else. This method may have some positive impact on performance too, since it will only add what's needed through `ReactRedux.connect()` (mapState and/or mapDispatch).

Many compile-time checks are done to ensure typing is correct. Compilation warnings / errors will be issued depending on the issue.

### VisibleTodoList example

#### Haxe version

```haxe
// A ReactConnector providing `TodoListProps`, with `TodoList` as default wrapped component
class VisibleTodoList extends ReactConnector<TodoList, TodoListProps>
{
	static function mapStateToProps(state:ApplicationState, ownProps:Dynamic):Partial<TodoListProps>
	{
		return {
			todos: getVisibleTodos(state.todoList.todos, state.todoList.visibilityFilter)
		}
	}

	static function getVisibleTodos(todos:Array<TodoData>, filter:TodoFilter)
	{
		return switch (filter) {
			case SHOW_ALL: todos;
			case SHOW_COMPLETED: todos.filter(function(t) return t.completed);
			case SHOW_ACTIVE: todos.filter(function(t) return !t.completed);
		}
	}

	static function mapDispatchToProps(dispatch:Dispatch, ownProps:Dynamic):Partial<TodoListProps>
	{
		return {
			onTodoClick: function(id) {
				return dispatch(TodoAction.Toggle(id));
			}
		};
	}
}
```

```haxe
@:jsxStatic('render')
class TodoList
{
	static public function render(props:TodoListProps)
	{
		var todos = props.todos.map(function(todo) return jsx('
			<$Todo
				key=${todo.id}
				{...todo}
				onClick=${props.onTodoClick.bind(todo.id)}
			/>
		'));

		return jsx('
			<ul>
				$todos
			</ul>
		');
	}
}
```

You can then call the HOC like this:

```haxe
	override function render()
	{
		return jsx('<$VisibleTodoList />');
	}
```

#### Javascript version

http://redux.js.org/docs/basics/UsageWithReact.html#containersvisibletodolistjs

```javascript
const getVisibleTodos = (todos, filter) => {
	switch (filter) {
		case 'SHOW_ALL':
			return todos
		case 'SHOW_COMPLETED':
			return todos.filter(t => t.completed)
		case 'SHOW_ACTIVE':
			return todos.filter(t => !t.completed)
	}
}

const mapStateToProps = (state) => {
	return {
		todos: getVisibleTodos(state.todos, state.visibilityFilter)
	}
}

const mapDispatchToProps = (dispatch) => {
	return {
		onTodoClick: (id) => {
			dispatch(toggleTodo(id))
		}
	}
}

const VisibleTodoList = connect(
	mapStateToProps,
	mapDispatchToProps
)(TodoList)
```

http://redux.js.org/docs/basics/UsageWithReact.html#componentstodolistjs

```javascript
const TodoList = ({ todos, onTodoClick }) => (
	<ul>
		{todos.map(todo =>
			<Todo
				key={todo.id}
				{...todo}
				onClick={() => onTodoClick(todo.id)}
			/>
		)}
	</ul>
)

TodoList.propTypes = {
	todos: PropTypes.arrayOf(PropTypes.shape({
		id: PropTypes.number.isRequired,
		completed: PropTypes.bool.isRequired,
		text: PropTypes.string.isRequired
	}).isRequired).isRequired,
	onTodoClick: PropTypes.func.isRequired
}
```

### HOC's own props

If your HOC needs props, you can extend `ReactConnectorOfProps` instead of `ReactConnector`:

```haxe
class FilterLink extends ReactConnectorOfProps<Link, LinkProps, FilterLinkProps>
{
	static function mapStateToProps(state:ApplicationState, ownProps:FilterLinkProps):Partial<LinkProps>
	{
		return {
			active: ownProps.filter == state.todoList.visibilityFilter
		}
	}

	static function mapDispatchToProps(dispatch:Dispatch, ownProps:FilterLinkProps):Partial<LinkProps>
	{
		return {
			onClick: function() {
				return dispatch(TodoAction.SetVisibilityFilter(ownProps.filter));
			}
		};
	}
}
```

You can then use it like this:

```haxe
jsx('
	<ul>
		<li>
			<$FilterLink filter="SHOW_ALL" label="All" />
		</li>
		<li>
			<$FilterLink filter="SHOW_ACTIVE" label="Active" />
		</li>
		<li>
			<$FilterLink filter="SHOW_COMPLETED" label="Completed" />
		</li>
	</ul>
');
```

### Reusing the HOC with another wrapped component

In the above example, you can also use another component instead of `TodoList`, by using it as `children`:

```haxe
	override function render()
	{
		return jsx('
			<$VisibleTodoList>
				<$MyOtherTodoList />
			</$VisibleTodoList>
		');
	}
```

The generated props would be added to every direct child's props, and will override the default wrapped component.

You can also create HOCs without binding them to specific components, with `ReactGenericConnector<TProps>` or `ReactGenericConnectorOfProps<TProps, TOwnProps>`.
They will return an empty node at runtime if you do not provide any children, and issue a `console.error()` if you compiled with `-debug`.

### HOC composition

#### Composition hardcoded inside a connector

You can use a connector accepting ownProps as `TComponent` for another connector.

#### Composition via jsx

```haxe
jsx('
	<$FirstConnector>
		<$SecondConnector>
			<$Component />
		</$SecondConnector>
	</$FirstConnector>
');
```

### ReactConnector API

```haxe
/**
  A react-redux connector designed for a component TComponent, providing TProps
  from redux store.
*/
typedef ReactConnector<TComponent, TProps> = ReactConnect<TComponent, TProps, TVoid>;

/**
  A react-redux connector designed for a component TComponent, providing TProps
  from redux store and the connector's props (TOwnProps)
*/
typedef ReactConnectorOfProps<TComponent, TComponentProps, TOwnProps> = ReactConnect<TComponent, TComponentProps, TOwnProps>;

/**
  A react-redux connector for use with any component compatible with TProps.
  Will return an empty react node at runtime if used without children, with an
  error message if compiled with -debug.
*/
typedef ReactGenericConnector<TProps> = ReactConnect<TVoid, TProps, TVoid>;

/**
  A react-redux connector for use with any component compatible with TProps.
  This connector also accepts props of type TOwnProps.
  Will return an empty react node at runtime if used without children, with an
  error message if compiled with -debug.
*/
typedef ReactGenericConnectorOfProps<TProps, TOwnProps> = ReactConnect<TVoid, TProps, TOwnProps>;
```

### General notes

 * Explicit typing is needed for `mapStateToProps` and `mapDispatchToProps` functions, to allow macros to check typing
 * There is no way of knowing you application store's state type, so appState is typed as `Dynamic`
 * Connectors cannot use a functional component as default component, unless it's a `@:jsxStatic` class
 * Connectors handle `defaultProps` when they have ownProps
 * `displayName`s are handled, to allow easier debugging with react extension

 * React-redux defaults to `(dispatch) => ({dispatch})` for `mapDispatchToProps` when you pass `null`, meaning `dispatch` will be provided if you do not define a `mapDispatchToProps` returning an object. This behavior has *not* been reproduced here, instead the macro will use a function returning an empty object.

 * This PR needs some PRs from haxe-react:
	 * [#86](https://github.com/massiveinteractive/haxe-react/pull/86) for its JsxStaticMacro refactoring
	 * [#96](https://github.com/massiveinteractive/haxe-react/pull/96) for `ReactUtil.copyWithout()`
	 * [#97](https://github.com/massiveinteractive/haxe-react/pull/97) for pluggable ReactComponent build macros (for `@:connect`)

### Example app and Tests

The example app has been updated for this PR: https://github.com/kLabz/haxe-redux-todo/tree/redux/6

Tests have been added, using `enzyme`. You can find the tests [here](https://github.com/kLabz/haxe-redux-todo/blob/redux/6/src/test/suite/ReactConnectorTests.hx).



## `@:connect` meta on ReactComponent

Add support for `@:connect` meta on react components, as the `@connect` decorator of react-redux.
Note that typing is not checked here; however react-redux does some checks at runtime.

### `@:connect` without params

If you do not provide params to the connect meta, a macro will loop through your fields to find *static* fields named `mapStateToProps`, `mapDispatchToProps`, `mergeProps` or `options` and use those it found.

```haxe
@:connect
class MyComponent extends ReactComponentOfProps<Props>
{
	static function mapDispatchToProps(dispatch:Dispatch):Props
	{
		return {
			onClick: function() return dispatch(Actions.Click)
		};
	}

	override public function render()
	{
		return jsx('
			<button onClick=${props.onClick} />
		');
	}
}
```

### Providing params

You can use any function instead of your own static fields.

```haxe
@:connect(null, Helpers.myMapDispatchToProps)
class MyComponent extends ReactComponentOfProps<Props> {}
```

Or even declare your function inline, if you're into this:

```haxe
@:connect(null, function(dispatch:Dispatch) return {onClick: function() return dispatch(Actions.Click))
class MyComponent extends ReactComponentOfProps<Props> {}
```

Please note that you must respect the order of arguments of `ReactRedux.connect()`, so you must pass null as first argument if you only want to define `mapDispatchToProps`, for example.