### PR TITLE
Public Action constructor + specific Action type naming

### DIFF
--- a/redux/Redux.hx
+++ b/redux/Redux.hx
@@ -1,6 +1,7 @@
 package redux;
 
 import js.Promise;
+using haxe.EnumTools.EnumValueTools;
 
 #if redux_global
 @:native('Redux')
@@ -58,10 +59,9 @@ abstract Action(ActionPayload)
 	
 	@:from static public function map(ev:EnumValue)
 	{
-		var e = Type.getEnum(ev);
 		return new Action({
-			type:e.getName(),
-			value:ev
+			type: Type.getEnum(ev).getName() + '.' + ev.getName(),
+			value: ev
 		});
 	}
 }

--- a/redux/Redux.hx
+++ b/redux/Redux.hx
@@ -51,7 +51,7 @@ typedef ActionPayload = {
 @:forward(type, value)
 abstract Action(ActionPayload)
 {
-	inline function new(a:ActionPayload)
+	public inline function new(a:ActionPayload)
 	{
 		this = a;
 	}

--- a/redux/StoreBuilder.hx
+++ b/redux/StoreBuilder.hx
@@ -14,7 +14,7 @@ class StoreBuilder
 		var type = of.getName();
 		return function(state:Dynamic, action:ActionPayload) {
 			if (state == null) state = service.initState;
-			if (action.type == type) return service.reduce(state, action.value);
+			if (StringTools.startsWith(action.type, type)) return service.reduce(state, action.value);
 			else return state;
 		}
 	}

--- a/redux/StoreBuilder.hx
+++ b/redux/StoreBuilder.hx
@@ -14,7 +14,7 @@ class StoreBuilder
 		var type = of.getName();
 		return function(state:Dynamic, action:ActionPayload) {
 			if (state == null) state = service.initState;
-			if (StringTools.startsWith(action.type, type)) return service.reduce(state, action.value);
+			if (action.type.lastIndexOf('.') != -1 && action.type.substr(0, action.type.lastIndexOf('.')) == type) return service.reduce(state, action.value);
 			else return state;
 		}
 	}


### PR DESCRIPTION
This PR does two things:

1. Allow direct creation of `Action` objects, instead of being forced to cast from enums (i.e., can now call `store.dispatch(new Action({ type: 'LOAD' }));`) for situtations where enum casting is inappropriate
2. Use the fully-qualified `EnumValue` name as the action name, rather than just the enum name (see below). While the old functionality worked, it didn't quite align with Redux, especially when using Redux Dev Tools. This change makes action names a bit more sane.

In the existing method, when an enum action is dispatched, it goes by its enum's name, despite the value. So if you group your actions like so:

```haxe
enum AuthActions {
    SignIn(token:String);
    SignOut;
}
```

Dispatching either the `SignIn` or `SignOut` actions would actually result in dispatching an `AuthActions` action, with the value of the action storing the enum value. i.e.:

```haxe
store.dispatch(AuthActions.SignIn('abc'));
store.dispatch(AuthActions.SignOut);
```

results in:

```javascript
store.dispatch({
    type: "AuthActions",
    value: ["SignIn", 0, "abc"]
});
store.dispatch({
    type: "AuthActions",
    value: ["SignOut", 1]
});
```

Notice how both actions are actually one single type? In Redux Dev Tools, it becomes very difficult to distinguish between a sign in action and a sign out action. With these changes, the code results instead in:

```javascript
store.dispatch({
    type: "AuthActions.SignIn",
    value: ["SignIn", 0, "abc"]
});
store.dispatch({
    type: "AuthActions.SignOut",
    value: ["SignOut", 1]
});
```

Which makes it much easier to track what is going on.