### PR TITLE
Support for @:connect on ReactComponent

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,2 +1,1 @@
-# Add support for @:connect on react components
---macro redux.react.ReactConnectorMacro.addBuilder()
+--macro redux.macro.ReduxMacro.initMacro()

--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,0 +1,2 @@
+# Add support for @:connect on react components
+--macro redux.react.ReactConnectorMacro.addBuilder()

--- a/redux/macro/ReduxMacro.hx
+++ b/redux/macro/ReduxMacro.hx
@@ -1,0 +1,12 @@
+package redux.macro;
+
+class ReduxMacro
+{
+	static public function initMacro()
+	{
+		#if react
+		redux.react.ReactConnectorMacro.addBuilder();
+		#end
+	}
+}
+

--- a/redux/macro/ReduxMacro.hx
+++ b/redux/macro/ReduxMacro.hx
@@ -4,7 +4,7 @@ class ReduxMacro
 {
 	static public function initMacro()
 	{
-		#if react
+		#if (react || react_next)
 		redux.react.ReactConnectorMacro.addBuilder();
 		#end
 	}

--- a/redux/react/ReactConnectorMacro.hx
+++ b/redux/react/ReactConnectorMacro.hx
@@ -1,0 +1,98 @@
+package redux.react;
+
+import haxe.macro.ComplexTypeTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+import react.jsx.JsxStaticMacro;
+import react.ReactMacro;
+
+class ReactConnectorMacro {
+	static inline var CONNECT_META = ':connect';
+	static inline var CONNECTED_META = ':connected_by_macro';
+	static inline var DEFAULT_CONNECTED_FIELD_NAME = '_connected';
+
+	static function addBuilder() react.ReactComponentMacro.appendBuilder(buildComponent);
+
+	static function buildComponent(inClass:ClassType, fields:Array<Field>):Array<Field>
+	{
+		if (inClass.meta.has(CONNECTED_META)) return fields;
+
+		if (inClass.meta.has(CONNECT_META))
+		{
+			if (inClass.meta.has(JsxStaticMacro.META_NAME))
+				Context.fatalError(
+					'Cannot use @${CONNECT_META} and @${JsxStaticMacro.META_NAME} on the same component',
+					inClass.pos
+				);
+
+			var fieldName = DEFAULT_CONNECTED_FIELD_NAME;
+			while (hasField(fields, fieldName)) fieldName = '_$fieldName';
+
+			var connectMeta = inClass.meta.extract(CONNECT_META).shift();
+			var connectParams = getConnectParams(connectMeta.params, fields);
+
+			fields.push({
+				access: [APublic, AStatic],
+				name: fieldName,
+				kind: FVar(null, macro redux.react.ReactRedux.connect($a{connectParams})($i{inClass.name})),
+				doc: null,
+				meta: null,
+				pos: connectMeta.pos
+			});
+
+			inClass.meta.add(JsxStaticMacro.META_NAME, [macro $v{fieldName}], connectMeta.pos);
+			inClass.meta.add(CONNECTED_META, [], inClass.pos);
+		}
+
+		return fields;
+	}
+
+	static function getConnectParams(params:Array<Expr>, fields:Array<Field>):Array<Expr>
+	{
+		if (params.length > 0) return params;
+
+		var mapStateToProps:Null<Expr> = null;
+		var mapDispatchToProps:Null<Expr> = null;
+		var mergeProps:Null<Expr> = null;
+		var options:Null<Expr> = null;
+
+		for (f in fields)
+		{
+			if (Lambda.has(f.access, AStatic))
+			{
+				switch (f.name)
+				{
+					case 'mapStateToProps': mapStateToProps = macro mapStateToProps;
+					case 'mapDispatchToProps': mapDispatchToProps = macro mapDispatchToProps;
+					case 'mergeProps': mergeProps = macro mergeProps;
+					case 'options': options = macro options;
+					default:
+				}
+			}
+		}
+
+		if (mapStateToProps == null && mapDispatchToProps == null && mergeProps == null && options == null)
+			return [];
+
+		if (mapStateToProps == null) mapStateToProps = macro null;
+		if (mapDispatchToProps == null && (mergeProps != null || options != null)) mapDispatchToProps = macro null;
+		if (mergeProps == null && options != null) mergeProps = macro null;
+
+		var ret = [mapStateToProps];
+		if (mapDispatchToProps != null) ret.push(mapDispatchToProps);
+		if (mergeProps != null) ret.push(mergeProps);
+		if (options != null) ret.push(options);
+		return ret;
+	}
+
+	static function hasField(fields:Array<Field>, fieldName:String):Bool
+	{
+		for (f in fields)
+			if (f.name == fieldName) return true;
+
+		return false;
+	}
+}

--- a/redux/react/ReactConnectorMacro.hx
+++ b/redux/react/ReactConnectorMacro.hx
@@ -16,7 +16,7 @@ class ReactConnectorMacro {
 	static inline var DEFAULT_CONNECTED_FIELD_NAME = '_connected';
 
 	// Use prepend to ensure @:connect is handled before @:wrap
-	static function addBuilder() react.ReactComponentMacro.prependBuilder(buildComponent);
+	static public function addBuilder() react.ReactComponentMacro.prependBuilder(buildComponent);
 
 	static function buildComponent(inClass:ClassType, fields:Array<Field>):Array<Field>
 	{

--- a/redux/react/ReactRedux.hx
+++ b/redux/react/ReactRedux.hx
@@ -3,7 +3,12 @@ package redux.react;
 import haxe.Constraints.Function;
 import redux.Redux;
 import react.Partial;
+
+#if react_next
+import react.ReactNode;
+#else
 import react.React.CreateElementType;
+#end
 
 #if reactredux_global
 @:native('ReactRedux')
@@ -18,13 +23,21 @@ extern class ReactRedux
 		?mapDispatchToProps: Dynamic,
 		?mergeProps: TStateProps -> TDispatchProps -> TOwnProps -> TProps,
 		?options: Partial<ConnectOptions>
+	#if react_next
+	): ReactNodeOf<TProps> -> ReactNodeOf<TOwnProps>;
+	#else
 	): CreateElementType -> CreateElementType;
+	#end
 
 	// https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectadvancedselectorfactory-connectoptions
 	public static function connectAdvanced<TFactoryOptions, TState, TOwnProps, TProps, TOptions:ConnectAdvancedOptions>(
 		selectorFactory: Dispatch -> TFactoryOptions -> (TState -> TOwnProps -> TProps),
 		?connectOptions: TOptions
-	):CreateElementType -> CreateElementType;
+	#if react_next
+	): ReactNodeOf<TProps> -> ReactNodeOf<TOwnProps>;
+	#else
+	): CreateElementType -> CreateElementType;
+	#end
 }
 
 typedef ConnectAdvancedOptions = {

--- a/redux/react/ReactRedux.hx
+++ b/redux/react/ReactRedux.hx
@@ -5,7 +5,7 @@ import redux.Redux;
 import react.Partial;
 
 #if react_next
-import react.ReactNode;
+import react.ReactType;
 #else
 import react.React.CreateElementType;
 #end
@@ -24,7 +24,7 @@ extern class ReactRedux
 		?mergeProps: TStateProps -> TDispatchProps -> TOwnProps -> TProps,
 		?options: Partial<ConnectOptions>
 	#if react_next
-	): ReactNodeOf<TProps> -> ReactNodeOf<TOwnProps>;
+	): ReactTypeOf<TProps> -> ReactTypeOf<TOwnProps>;
 	#else
 	): CreateElementType -> CreateElementType;
 	#end
@@ -34,7 +34,7 @@ extern class ReactRedux
 		selectorFactory: Dispatch -> TFactoryOptions -> (TState -> TOwnProps -> TProps),
 		?connectOptions: TOptions
 	#if react_next
-	): ReactNodeOf<TProps> -> ReactNodeOf<TOwnProps>;
+	): ReactTypeOf<TProps> -> ReactTypeOf<TOwnProps>;
 	#else
 	): CreateElementType -> CreateElementType;
 	#end


### PR DESCRIPTION
## `@:connect` meta on ReactComponent

Add support for `@:connect` meta on react components, as the `@connect` decorator of react-redux.
Note that typing is not checked here; however react-redux does some checks at runtime.

### `@:connect` without params

If you do not provide params to the connect meta, a macro will loop through your fields to find *static* fields named `mapStateToProps`, `mapDispatchToProps`, `mergeProps` or `options` and use those it found.

```haxe
@:connect
class MyComponent extends ReactComponentOfProps<Props>
{
	static function mapDispatchToProps(dispatch:Dispatch):Props
	{
		return {
			onClick: function() return dispatch(Actions.Click)
		};
	}

	override public function render()
	{
		return jsx('
			<button onClick=${props.onClick} />
		');
	}
}
```

### Providing params

You can use any function instead of your own static fields.

```haxe
@:connect(null, Helpers.myMapDispatchToProps)
class MyComponent extends ReactComponentOfProps<Props> {}
```

Or even declare your function inline, if you're into this:

```haxe
@:connect(null, function(dispatch:Dispatch) return {onClick: function() return dispatch(Actions.Click))
class MyComponent extends ReactComponentOfProps<Props> {}
```

Please note that you must respect the order of arguments of `ReactRedux.connect()`, so you must pass null as first argument if you only want to define `mapDispatchToProps`, for example.