### PR TITLE
Allow thunk with Void return

### DIFF
--- a/redux/thunk/Thunk.hx
+++ b/redux/thunk/Thunk.hx
@@ -3,7 +3,7 @@ package redux.thunk;
 import redux.Redux.Dispatch;
 
 enum Thunk<TState, TParams> {
-	Action(cb:Dispatch->(Void->TState)->Dynamic);
-	WithParams(cb:Dispatch->(Void->TState)->Null<TParams>->Dynamic);
+	Action<TReturn>(cb:Dispatch->(Void->TState)->TReturn);
+	WithParams<TReturn>(cb:Dispatch->(Void->TState)->Null<TParams>->TReturn);
 }
 

--- a/redux/thunk/ThunkMiddleware.hx
+++ b/redux/thunk/ThunkMiddleware.hx
@@ -11,13 +11,13 @@ class ThunkMiddleware<TState, TParams> implements IMiddleware<Thunk<TState, TPar
 		this.params = params;
 	}
 
-	public function middleware(action:Thunk<TState, TParams>, next:Void->Dynamic):Dynamic {
+	public function middleware(action:Thunk<TState, TParams>, next:Void->Dynamic):Any {
 		return switch (action) {
 			case Action(cb):
-				return cb(store.dispatch, store.getState);
+				cb(store.dispatch, store.getState);
 
 			case WithParams(cb):
-				return cb(store.dispatch, store.getState, this.params);
-		}
+				cb(store.dispatch, store.getState, this.params);
+		};
 	}
 }


### PR DESCRIPTION
The way thunk were handled did not allow for functions returning `Void`. With this change, both are supported.