### PR TITLE
Fix prop types for react-next

### DIFF
--- a/redux/react/Provider.hx
+++ b/redux/react/Provider.hx
@@ -7,7 +7,11 @@ import redux.StoreMethods;
 
 typedef ProvideProps = {
 	store: StoreMethods<Dynamic>,
+	#if react_next
+	children: ReactSingleFragment
+	#else
 	children: ReactElement
+	#end
 }
 
 class Provider extends ReactComponentOfProps<ProvideProps>


### PR DESCRIPTION
`redux`'s Provider breaks with latest `react-next` (only when using literals) because of its `children` prop type which is too restrictive.

This has no impact when using `haxe-react` instead.