### PR TITLE
Rename ReactNode to ReactType

### DIFF
--- a/redux/react/Provider.hx
+++ b/redux/react/Provider.hx
@@ -7,7 +7,11 @@ import redux.StoreMethods;
 
 typedef ProvideProps = {
 	store: StoreMethods<Dynamic>,
+	#if react_next
+	children: ReactSingleFragment
+	#else
 	children: ReactElement
+	#end
 }
 
 class Provider extends ReactComponentOfProps<ProvideProps>

--- a/redux/react/ReactRedux.hx
+++ b/redux/react/ReactRedux.hx
@@ -3,7 +3,12 @@ package redux.react;
 import haxe.Constraints.Function;
 import redux.Redux;
 import react.Partial;
+
+#if react_next
+import react.ReactType;
+#else
 import react.React.CreateElementType;
+#end
 
 #if reactredux_global
 @:native('ReactRedux')
@@ -18,13 +23,21 @@ extern class ReactRedux
 		?mapDispatchToProps: Dynamic,
 		?mergeProps: TStateProps -> TDispatchProps -> TOwnProps -> TProps,
 		?options: Partial<ConnectOptions>
+	#if react_next
+	): ReactTypeOf<TProps> -> ReactTypeOf<TOwnProps>;
+	#else
 	): CreateElementType -> CreateElementType;
+	#end
 
 	// https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectadvancedselectorfactory-connectoptions
 	public static function connectAdvanced<TFactoryOptions, TState, TOwnProps, TProps, TOptions:ConnectAdvancedOptions>(
 		selectorFactory: Dispatch -> TFactoryOptions -> (TState -> TOwnProps -> TProps),
 		?connectOptions: TOptions
-	):CreateElementType -> CreateElementType;
+	#if react_next
+	): ReactTypeOf<TProps> -> ReactTypeOf<TOwnProps>;
+	#else
+	): CreateElementType -> CreateElementType;
+	#end
 }
 
 typedef ConnectAdvancedOptions = {


### PR DESCRIPTION
Follow the renaming of `ReactNode` to `ReactType` in `react-next`.
Also includes a small fix in the Provider props.

**Does not have any effect when using `react` instead of `react-next`.**